### PR TITLE
Fixing the link to the mobile opportunity wiki

### DIFF
--- a/_website/_layout.jade
+++ b/_website/_layout.jade
@@ -32,7 +32,7 @@ html
                   a(href="questions#questions") Questions
 
             p Our work is public.  You can track our
-              <a href="wiki.mozilla.org/Mobile_Opportunity">wiki documentation</a>
+              <a href="https://wiki.mozilla.org/Mobile_Opportunity">wiki documentation</a>
               , as well as our <a href="https://github.com/mozilla/mobile-opportunity/issues/milestones">issue tracking</a>.
               
             p This website is authored in github, edits via <a href="https://github.com/mozilla/mobile-opportunity/tree/master/_website">pull requests</a> or <a href="https://github.com/mozilla/mobile-opportunity/issues/new">issues</a> are welcome.


### PR DESCRIPTION
The link to the mobile opportunity wiki is broken.  This is a fix.
